### PR TITLE
Added token validation and salt for user

### DIFF
--- a/SecurityStatelessGrailsPlugin.groovy
+++ b/SecurityStatelessGrailsPlugin.groovy
@@ -1,14 +1,22 @@
+import net.kaleidos.grails.plugin.security.stateless.StatelessService
+import net.kaleidos.grails.plugin.security.stateless.CryptoService
+
 import net.kaleidos.grails.plugin.security.stateless.filter.StatelessAuthenticationFilter
 import net.kaleidos.grails.plugin.security.stateless.filter.StatelessLoginFilter
+import net.kaleidos.grails.plugin.security.stateless.filter.StatelessInvalidateTokenFilter
+
 import net.kaleidos.grails.plugin.security.stateless.handler.StatelessAuthenticationFailureHandler
+
 import net.kaleidos.grails.plugin.security.stateless.provider.StatelessAuthenticationProvider
-import net.kaleidos.grails.plugin.security.stateless.StatelessService
+import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
+
+import net.kaleidos.grails.plugin.security.stateless.token.StatelessTokenValidator
 
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.SecurityFilterPosition
 
 class SecurityStatelessGrailsPlugin {
-    def version = "0.0.1-SNAPSHOT"
+    def version = "0.0.2-SNAPSHOT"
     def grailsVersion = "2.2 > *"
     def title = "Grails Spring Security Stateless Plugin"
     def description = 'Implements stateless authentication, with optional use of using Spring Security.'
@@ -20,6 +28,17 @@ class SecurityStatelessGrailsPlugin {
     def issueManagement = [system: 'GITHUB', url: 'https://github.com/kaleidos/grails-security-stateless/issues']
     def loadAfter = ["springSecurityCore"]
 
+    def pluginExcludes = [
+        "grails-app/views/error.gsp",
+        "grails-app/controllers/**",
+        "grails-app/domain/**",
+        "grails-app/i18n/**",
+        "grails-app/taglib/**",
+        "grails-app/utils/**",
+        "grails-app/views/**",
+        "web-app/**"
+    ]
+
     def doWithSpring = {
         def conf = application.config.grails.plugin.security.stateless.springsecurity
 
@@ -29,7 +48,17 @@ class SecurityStatelessGrailsPlugin {
 
         println '\nConfiguring Spring Security Stateless ...'
 
-        statelessService(StatelessService)
+        userSaltProvider(UserSaltProvider)
+        cryptoService(CryptoService)
+
+        statelessService(StatelessService) {
+            userSaltProvider = ref("userSaltProvider")
+            cryptoService = ref("cryptoService")
+        }
+
+        statelessTokenValidator(StatelessTokenValidator){
+            userSaltProvider = ref("userSaltProvider")
+        }
 
         statelessAuthenticationFilter(StatelessAuthenticationFilter) {
             authenticationFailureHandler = ref('statelessAuthenticationFailureHandler')
@@ -40,6 +69,7 @@ class SecurityStatelessGrailsPlugin {
         statelessAuthenticationProvider(StatelessAuthenticationProvider) {
             userDetailsService = ref('userDetailsService')
             statelessService = ref('statelessService')
+            statelessTokenValidator = ref('statelessTokenValidator')
         }
 
         statelessAuthenticationFailureHandler(StatelessAuthenticationFailureHandler)
@@ -53,18 +83,41 @@ class SecurityStatelessGrailsPlugin {
             passwordField = conf.login.passwordField?:"password"
             active = conf.login.active?:false
         }
+
+        statelessInvalidateTokenFilter(StatelessInvalidateTokenFilter) {
+            statelessService = ref('statelessService')
+            userSaltProvider = ref('userSaltProvider')
+            endpointUrl = conf.invalidate.endpointUrl
+            active = conf.invalidate.active?:false
+        }
+
         SpringSecurityUtils.registerFilter('statelessAuthenticationFilter', SecurityFilterPosition.SECURITY_CONTEXT_FILTER.order + 10)
         SpringSecurityUtils.registerFilter('statelessLoginFilter', SecurityFilterPosition.FIRST.order + 1)
+        SpringSecurityUtils.registerFilter('statelessInvalidateTokenFilter', SecurityFilterPosition.FIRST.order + 2)
+
         println '\n... finished configuring Spring Security Stateless'
     }
-    
+
     def doWithApplicationContext = { ctx ->
         def conf = ctx.grailsApplication.config.grails.plugin.security.stateless
 
         if (!conf.secretKey) {
             throw new RuntimeException("Spring security stateles secretKey not configured or empty. Please, set 'grails.plugin.security.stateless.secretKey' value in your Config.groovy")
         }
-        ctx.statelessService.init("${conf.secretKey}", conf.cypher?true:false)
+
+        ctx.statelessService.init "${conf.secretKey}"
         ctx.cryptoService.init "${conf.secretKey}"
+
+        def securityConf = SpringSecurityUtils.securityConfig
+        String userClassName = securityConf.userLookup.userDomainClassName
+
+        def userClass = ctx.grailsApplication.getDomainClass(userClassName).clazz
+        def usernamePropertyName = securityConf.userLookup.usernamePropertyName
+
+        if (conf.expirationTime) {
+            ctx.statelessTokenValidator.init(new Integer(conf.expirationTime))
+        }
+
+        ctx.userSaltProvider?.init(userClass, usernamePropertyName, conf.saltField?:"salt")
     }
 }

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -14,10 +14,20 @@ grails.project.dependency.resolution = {
 
     dependencies {
         compile "net.sf.ehcache:ehcache-core:2.4.8"
+        compile 'joda-time:joda-time:2.4'
+
+        // Unit testing domain gorm access
+        test 'org.grails:grails-datastore-test-support:1.0-grails-2.4'
+
+        // In order to support mock of classes
+        test 'cglib:cglib-nodep:2.2'
     }
 
     plugins {
         compile ":spring-security-core:2.0-RC4"
+
+        test ':hibernate4:4.3.5.4'
+
         build ':release:3.0.1', ':rest-client-builder:2.0.3', {
            export = false
         }

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1,4 +1,5 @@
 // Only for testing purpouses
+grails.plugin.springsecurity.userLookup.userDomainClassName = 'test.TestUser'
 grails.plugin.security.stateless.secretKey = "mysecretkey"
 
 log4j = {

--- a/grails-app/domain/test/TestUser.groovy
+++ b/grails-app/domain/test/TestUser.groovy
@@ -1,0 +1,11 @@
+package test
+
+class TestUser {
+    String username
+    String salt
+
+    static constraints = {
+        username nullable: false
+        salt nullable: true
+    }
+}

--- a/grails-app/services/net/kaleidos/grails/plugin/security/stateless/CryptoService.groovy
+++ b/grails-app/services/net/kaleidos/grails/plugin/security/stateless/CryptoService.groovy
@@ -1,6 +1,5 @@
 package net.kaleidos.grails.plugin.security.stateless
 
-import grails.util.Holders as CH
 import groovy.transform.CompileStatic
 
 import java.security.NoSuchAlgorithmException

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessAuthenticationFilter.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessAuthenticationFilter.groovy
@@ -47,13 +47,12 @@ class StatelessAuthenticationFilter extends GenericFilterBean {
 
         try {
             logger.debug "Found bearer token in Authorization header"
-            tokenValue = servletRequest.getHeader( 'Authorization').substring(7)
+            tokenValue = servletRequest.getHeader('Authorization').substring(7)
             logger.debug "Trying to authenticate the token"
             StatelessAuthenticationToken authenticationRequest = new StatelessAuthenticationToken(tokenValue)
             StatelessAuthenticationToken authenticationResult = statelessAuthenticationProvider.authenticate(authenticationRequest) as StatelessAuthenticationToken
 
             if (authenticationResult.authenticated) {
-
                 logger.debug "Token authenticated."
                 logger.debug "Authentication result: ${authenticationResult}"
                 servletRequest.setAttribute 'securityStatelessMap', authenticationResult.securityStatelessMap

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessInvalidateTokenFilter.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessInvalidateTokenFilter.groovy
@@ -1,0 +1,66 @@
+package net.kaleidos.grails.plugin.security.stateless.filter
+
+import groovy.transform.CompileStatic
+
+import javax.servlet.FilterChain
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+import net.kaleidos.grails.plugin.security.stateless.StatelessService
+import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
+
+import org.springframework.web.filter.GenericFilterBean
+
+@CompileStatic
+class StatelessInvalidateTokenFilter extends GenericFilterBean {
+    boolean active
+
+    String endpointUrl
+
+    UserSaltProvider userSaltProvider
+    StatelessService statelessService
+
+    void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = request as HttpServletRequest
+        HttpServletResponse httpServletResponse = response as HttpServletResponse
+
+        def actualUri =  httpServletRequest.requestURI - httpServletRequest.contextPath
+
+        logger.debug "Actual URI is ${actualUri}; endpoint URL is ${endpointUrl}"
+
+        //Only apply filter to the configured URL
+        if (!active || (actualUri != endpointUrl)) {
+            chain.doFilter(request, response)
+            return
+        }
+
+        logger.debug "Applying authentication filter to this request"
+
+        //Only POST is supported
+        if (httpServletRequest.method != 'POST') {
+            logger.debug "${httpServletRequest.method} HTTP method is not supported. Setting status to ${HttpServletResponse.SC_METHOD_NOT_ALLOWED}"
+            httpServletResponse.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED)
+            return
+        }
+
+        // Get current token
+        def tokenValue = httpServletRequest.getHeader('Authorization')
+        if (!tokenValue) {
+            logger.debug "Authorization header not present"
+            httpServletResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST) //400
+            return
+        }
+
+        try {
+            def tokenData = statelessService.validateAndExtractToken(tokenValue)
+            userSaltProvider.updateUserSalt(tokenData.username as String, UUID.randomUUID().toString())
+            return
+        } catch (Exception e) {
+            log.debug "Problem updating the user salt: ${e.message}"
+            httpServletResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST) //400
+        }
+    }
+}

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessLoginFilter.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessLoginFilter.groovy
@@ -29,6 +29,7 @@ class StatelessLoginFilter extends GenericFilterBean {
 
     AuthenticationManager authenticationManager
     AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource
+
     StatelessService statelessService
 
     void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/provider/StatelessAuthenticationProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/provider/StatelessAuthenticationProvider.groovy
@@ -2,11 +2,10 @@ package net.kaleidos.grails.plugin.security.stateless.provider
 
 import grails.plugin.springsecurity.userdetails.GrailsUserDetailsService
 import groovy.transform.CompileStatic
-import net.kaleidos.grails.plugin.security.stateless.StatelessService
-import net.kaleidos.grails.plugin.security.stateless.token.StatelessAuthenticationToken
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+
 import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.core.Authentication
@@ -14,16 +13,20 @@ import org.springframework.security.core.AuthenticationException
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.util.Assert
 
+import net.kaleidos.grails.plugin.security.stateless.StatelessService
+import net.kaleidos.grails.plugin.security.stateless.token.StatelessAuthenticationToken
+import net.kaleidos.grails.plugin.security.stateless.token.StatelessTokenValidator
+
+
 @CompileStatic
 class StatelessAuthenticationProvider implements AuthenticationProvider {
-
     protected final Logger log = LoggerFactory.getLogger(getClass().name)
 
     GrailsUserDetailsService userDetailsService
     StatelessService statelessService
+    StatelessTokenValidator statelessTokenValidator
 
     Authentication authenticate(Authentication authentication) throws AuthenticationException {
-
         Assert.isInstanceOf(StatelessAuthenticationToken, authentication, "Only StatelessAuthenticationToken is supported")
         StatelessAuthenticationToken authenticationRequest = (StatelessAuthenticationToken)authentication
         StatelessAuthenticationToken authenticationResult = new StatelessAuthenticationToken(authenticationRequest.tokenValue)
@@ -32,13 +35,16 @@ class StatelessAuthenticationProvider implements AuthenticationProvider {
             throw new BadCredentialsException("Token invalid")
         }
 
-
         log.debug "Trying to validate token ${authenticationRequest.tokenValue}"
-
 
         def securityStatelessMap = statelessService.validateAndExtractToken(authenticationRequest.tokenValue)
         if (securityStatelessMap) {
             UserDetails userDetails = userDetailsService.loadUserByUsername((String)securityStatelessMap.username, true)
+
+            if (!statelessTokenValidator.validate(securityStatelessMap, userDetails)){
+                throw new BadCredentialsException("Token invalid")
+            }
+
             log.debug "Authentication result: ${authenticationResult}"
             authenticationResult = new StatelessAuthenticationToken(userDetails, userDetails.password, userDetails.authorities, authenticationRequest.tokenValue)
             authenticationResult.securityStatelessMap = securityStatelessMap

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/provider/UserSaltProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/provider/UserSaltProvider.groovy
@@ -1,0 +1,56 @@
+package net.kaleidos.grails.plugin.security.stateless.provider
+
+import grails.plugin.springsecurity.userdetails.NoStackUsernameNotFoundException;
+import org.springframework.util.Assert
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class UserSaltProvider {
+    protected final Logger log = LoggerFactory.getLogger(getClass().name)
+
+    Class<?> userClass
+    String usernameProperty
+    String saltField
+
+    public void init(Class<?> userClass, String usernameProperty, String saltField) {
+        Assert.notNull(userClass, "User class cannot be null")
+        Assert.notNull(usernameProperty, "Username property field should be specified")
+        Assert.notNull(saltField, "Salt property field should be specified")
+
+        this.userClass = userClass
+        this.usernameProperty = usernameProperty
+        this.saltField = saltField
+    }
+
+    public String getUserSalt(String username){
+        String salt = null
+        userClass.withTransaction { status ->
+            def user = userClass.findWhere((usernameProperty): username)
+
+            if (!user) {
+                salt = null
+            } else if (userClass.metaClass.hasProperty(user, saltField)) {
+                salt = user."$saltField"
+            } else {
+                throw new RuntimeException("$userClass class needs $saltField field")
+            }
+        }
+        return salt
+    }
+
+    public void updateUserSalt(String username, String salt) {
+        userClass.withTransaction { status ->
+            def user = userClass.findWhere((usernameProperty): username)
+
+            if (!user) {
+                throw new RuntimeException("User not found")
+            } else if (userClass.metaClass.hasProperty(user, saltField)) {
+                user."$saltField" = salt
+                user.save(failOnError: true)
+            } else {
+                throw new RuntimeException("$userClass class needs $saltField field")
+            }
+        }
+    }
+}

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/StatelessTokenValidator.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/StatelessTokenValidator.groovy
@@ -1,0 +1,52 @@
+package net.kaleidos.grails.plugin.security.stateless.token
+
+import grails.util .Holders
+
+import groovy.transform.CompileStatic
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import org.springframework.security.core.userdetails.UserDetails
+
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormatter
+import org.joda.time.format.ISODateTimeFormat
+
+import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
+
+@CompileStatic
+public class StatelessTokenValidator {
+    UserSaltProvider userSaltProvider
+
+    Integer expirationTime
+
+    public void init(Integer expirationTime) {
+        this.expirationTime = expirationTime
+    }
+
+    public boolean validate(Map securityStatelessMap, UserDetails userDetails) {
+        boolean validationResult = true
+
+        if (!userDetails.enabled || !userDetails.accountNonExpired || !userDetails.credentialsNonExpired || !userDetails.accountNonLocked){
+            validationResult = false
+        }
+
+        if (validationResult && expirationTime != null && securityStatelessMap["issued_at"]) {
+            def formatter = ISODateTimeFormat.dateTime()
+            def issuedAt = formatter.parseDateTime(""+securityStatelessMap["issued_at"])
+            validationResult = issuedAt.plusMinutes(expirationTime).isAfterNow()
+        }
+
+        if (validationResult && userSaltProvider) {
+            String userSalt = userSaltProvider.getUserSalt(userDetails.username)
+
+            if (!userSalt && !securityStatelessMap["salt"]) {
+                validationResult = true
+            } else if (userSalt != securityStatelessMap["salt"]) {
+                validationResult = false
+            }
+        }
+        return validationResult
+    }
+}

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/StatelessServiceSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/StatelessServiceSpec.groovy
@@ -3,86 +3,60 @@ package net.kaleidos.grails.plugin.security.stateless
 import grails.test.mixin.TestFor
 import spock.lang.Specification
 
+import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
+
+
 @TestFor(StatelessService)
 class StatelessServiceSpec extends Specification {
 
     def setup() {
-        service.init "secret", false
-          service.cryptoService = new CryptoService()
-          service.cryptoService.init 'secret'
+        service.init "secret"
+        service.cryptoService = new CryptoService()
+        service.cryptoService.init 'secret'
+        service.userSaltProvider = Mock(UserSaltProvider)
+        service.userSaltProvider.getUserSalt(_) >> "salt"
     }
 
-    void "generate a token"() {
+    void "generate a token and then extract it"() {
         setup:
             def username = 'palba'
-        when:
             def token = service.generateToken(username)
-        then:
-            token == "eyJ1c2VybmFtZSI6InBhbGJhIiwiZXh0cmFkYXRhIjp7fX1fenBMTklBa0o0MXpNVVZnUm9kVGlta1FueEM3U0ZVMGZkaGJUaUZWOFpPST0="
-    }
 
-
-    void "validate a token"() {
-        setup:
-            def token = "Bearer eyJ1c2VybmFtZSI6InBhbGJhIiwiZXh0cmFkYXRhIjp7fX1fenBMTklBa0o0MXpNVVZnUm9kVGlta1FueEM3U0ZVMGZkaGJUaUZWOFpPST0="
         when:
             def data = service.validateAndExtractToken(token)
+
         then:
             data.username == 'palba'
             data.extradata == [:]
+            data.issued_at != null
+            data.salt == "salt"
     }
 
     void "generate a token with extra data"() {
         setup:
             def username = 'palba'
             def extraData = ['token1':'AAA', 'token2':'BBB']
-        when:
             def token = service.generateToken(username, extraData)
-        then:
-            token == "eyJ1c2VybmFtZSI6InBhbGJhIiwiZXh0cmFkYXRhIjp7InRva2VuMSI6IkFBQSIsInRva2VuMiI6IkJCQiJ9fV81RDRFUzFLSzZlRHhZdDV1em5vTThKR0pzczlBMDE0bEprMS8rV1R4TVpjPQ=="
-    }
 
-    void "validate a token with extra data"() {
-        setup:
-            def token = "Bearer eyJ1c2VybmFtZSI6InBhbGJhIiwiZXh0cmFkYXRhIjp7InRva2VuMSI6IkFBQSIsInRva2VuMiI6IkJCQiJ9fV81RDRFUzFLSzZlRHhZdDV1em5vTThKR0pzczlBMDE0bEprMS8rV1R4TVpjPQ=="
         when:
             def data = service.validateAndExtractToken(token)
+
         then:
             data.username == 'palba'
             data.extradata['token1'] == 'AAA'
             data.extradata['token2'] == 'BBB'
+            data.issued_at != null
+            data.salt == "salt"
     }
 
-    void "generate an encrypted token"() {
+    void "Try to extract invalid token"() {
         setup:
-            service.init "secret", true
-            def username = 'palba'
-        when:
-            def token = service.generateToken(username)
-        then:
-            token != "eyJ1c2VybmFtZSI6InBhbGJhIiwiZXh0cmFkYXRhIjp7fX1fenBMTklBa0o0MXpNVVZnUm9kVGlta1FueEM3U0ZVMGZkaGJUaUZWOFpPST0="
-    }
+            def token = "XXXXXXXXXXXX"
 
-    void "validate an encripted token"() {
-        setup:
-            service.init "secret", true
-            def token = "Bearer OWY3MTU0YTZmNjI2Zjc3YzA1YzkyZGI4MDFiMDVmYzNkMTRiMjRlOTIyNWZjMDQ4ZmIxYjVmZDQ4ZTdjNWQ4MzkyMGNmM2E0MjE0ZDI1NjFjMWMzOWUyODljM2FjZmYxNTdjNWExMTAwMjVjMTRmNTJlODZhNjYxYjg5NGJkYTRlMWU5NzdkZjE2MTMwN2JiZDM2OTYwNjcwYTBkMDYxYl93NGxJbnJ0V2R2Qjk3WEhpYWhTRW5OeVpBYmJTb2UwU3hTYURkMHFxVW5nPQ=="
         when:
             def data = service.validateAndExtractToken(token)
-        then:
-            data.username == 'palba'
-            data.extradata == [:]
-    }
 
-    void "generate and validate an encrypted token"() {
-        setup:
-            service.init "secret", false
-            def username = 'palba'
-        when:
-            def token = service.generateToken(username)
-            def data = service.validateAndExtractToken(token)
         then:
-            data.username == 'palba'
-            data.extradata == [:]
+            thrown(RuntimeException)
     }
 }

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/provider/UserSaltProviderSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/provider/UserSaltProviderSpec.groovy
@@ -1,0 +1,67 @@
+package net.kaleidos.grails.plugin.security.stateless.provider
+
+import spock.lang.Specification
+
+import grails.test.mixin.TestMixin
+import grails.test.mixin.gorm.Domain
+import grails.test.mixin.hibernate.HibernateTestMixin
+
+import test.TestUser
+
+@Domain(TestUser)
+@TestMixin(HibernateTestMixin)
+class UserSaltProviderSpec extends Specification {
+    void "Retrieve user salt"() {
+        setup:
+            def provider = new UserSaltProvider()
+            provider.init(TestUser, "username", "salt")
+
+            new TestUser(username: username, salt: salt).save(flush:true)
+
+        when:
+            def result = provider.getUserSalt(username)
+
+        then:
+            result == salt
+
+        where:
+            username = "test1"
+            salt = "salt"
+    }
+
+    void "Retrieve user salt (user doesn't exist')"() {
+        setup:
+            def provider = new UserSaltProvider()
+            provider.init(TestUser, "username", "salt")
+
+        when:
+            def result = provider.getUserSalt(username)
+
+        then:
+            result == null
+
+        where:
+            username = "test2"
+            salt = "salt"
+    }
+
+    void "Update user salt"() {
+        setup:
+            def provider = new UserSaltProvider()
+            provider.init(TestUser, "username", "salt")
+
+            new TestUser(username: username, salt: salt).save()
+
+        when:
+            provider.updateUserSalt(username, newSalt)
+            def result = TestUser.findByUsername(username)
+
+        then:
+            result.salt == newSalt
+
+        where:
+            username = "test3"
+            salt = "salt"
+            newSalt = "newSalt"
+    }
+}

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/token/StatelessTokenValidatorSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/token/StatelessTokenValidatorSpec.groovy
@@ -1,0 +1,127 @@
+package net.kaleidos.grails.plugin.security.stateless.token
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import grails.plugin.springsecurity.userdetails.GrailsUser
+import net.kaleidos.grails.plugin.security.stateless.token.StatelessTokenValidator
+
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormatter
+import org.joda.time.format.ISODateTimeFormat
+
+import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
+
+class StatelessTokenValidatorSpec extends Specification {
+    void "Validate a valid token"() {
+        setup:
+            def validator = new StatelessTokenValidator()
+
+        when:
+            def result = validator.validate([:], new GrailsUser(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, [], 1))
+
+        then:
+            result == true
+
+        where:
+            username = "test"
+            password = "test"
+            enabled = true
+            accountNonExpired = true
+            credentialsNonExpired = true
+            accountNonLocked = true
+    }
+
+    @Unroll
+    void "Not valid token: #enabled, #accountNonExpired, #credentialsNonExpired, #accountNonLocked"() {
+        setup:
+            def validator = new StatelessTokenValidator()
+
+        when:
+            def result = validator.validate([:], new GrailsUser(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, [], 1))
+
+        then:
+            result == false
+
+        where:
+            username = "test"
+            password = "test"
+            enabled << [false, true, true, true]
+            accountNonExpired << [true, false, true, true]
+            credentialsNonExpired << [true, true, false, true]
+            accountNonLocked << [true, true, true, false]
+    }
+
+    void "Expired token"() {
+        setup:
+            def validator = new StatelessTokenValidator()
+
+        and: "Setup expiration date for the validator"
+            validator.init(59)
+
+        and: "Create the issued at date inside the token"
+            def formatter = ISODateTimeFormat.dateTime()
+            String issuedAt = formatter.print(new DateTime().minusHours(1));
+
+        when:
+            def result = validator.validate(["issued_at" : issuedAt], new GrailsUser(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, [], 1))
+
+        then:
+            result == false
+
+        where:
+            username = "test"
+            password = "test"
+            enabled = true
+            accountNonExpired = true
+            credentialsNonExpired = true
+            accountNonLocked = true
+    }
+
+    @Unroll
+    void "User salt do match"() {
+        setup:
+            def validator = new StatelessTokenValidator()
+            validator.userSaltProvider = Mock(UserSaltProvider)
+            validator.userSaltProvider.getUserSalt(username) >> salt
+
+        when:
+            def result = validator.validate(["salt" : salt], new GrailsUser(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, [], 1))
+
+        then:
+            result == true
+
+        where:
+            username = "test1"
+            password = "test"
+            enabled = true
+            accountNonExpired = true
+            credentialsNonExpired = true
+            accountNonLocked = true
+            salt << ["salt", null]
+    }
+
+    @Unroll
+    void "User salt doesn't match"() {
+        setup:
+            def validator = new StatelessTokenValidator()
+            validator.userSaltProvider = Mock(UserSaltProvider)
+            validator.userSaltProvider.getUserSalt(username) >> salt2
+
+        when:
+            def result = validator.validate(["salt" : salt1], new GrailsUser(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked, [], 1))
+
+        then:
+            result == false
+
+        where:
+            username = "test2"
+            password = "test"
+            enabled = true
+            accountNonExpired = true
+            credentialsNonExpired = true
+            accountNonLocked = true
+            salt1 << ["salt1", null, "salt1"]
+            salt2 << ["salt2", "salt2", null]
+    }
+}


### PR DESCRIPTION
- Added validation for User status for the current token (check if the user is deactivated)
- Checks if the token issue date is older than the allowed date
- Add a field for users called "salt" to invalidate the user tokens
- Creates a new endpoint /api/invalidate to generate a new salt for the user
