### PR TITLE
Fix json login problem with locales

### DIFF
--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessLoginFilter.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessLoginFilter.groovy
@@ -58,9 +58,8 @@ class StatelessLoginFilter extends GenericFilterBean {
             return
         }
 
-
         String principal, credentials
-        if (["application/json", "text/json"].contains(httpServletRequest.contentType)) {
+        if (["application/json", "text/json"].any { httpServletRequest.contentType.contains(it) }) {
             def json = new JsonSlurper().parseText(httpServletRequest.reader.text)
             principal = json[usernameField]
             credentials = json[passwordField]


### PR DESCRIPTION
There was a problem when the content type contained the locale for example:

```
Content-Type: application/json; charset=UTF-8
```
