### PR TITLE
Fix not present token in validation

### DIFF
--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProvider.groovy
@@ -43,6 +43,11 @@ class JwtStatelessTokenProvider implements StatelessTokenProvider {
     }
 
     Map validateAndExtractToken(String token) {
+        if (!token) {
+            log.debug "Token must be present"
+            throw new StatelessValidationException("Invalid token")
+        }
+
         if (token.startsWith(BEARER)){
             token = token.substring(BEARER.size())
         }

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProvider.groovy
@@ -44,6 +44,11 @@ class LegacyStatelessTokenProvider implements StatelessTokenProvider {
     }
 
     Map validateAndExtractToken(String token) {
+        if (!token) {
+            log.debug "Token must be present"
+            throw new StatelessValidationException("Invalid token")
+        }
+
         if (token.startsWith(BEARER)){
             token = token.substring(BEARER.size())
         }

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProviderSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProviderSpec.groovy
@@ -5,6 +5,7 @@ import net.kaleidos.grails.plugin.security.stateless.CryptoService
 import grails.test.mixin.TestFor
 import spock.lang.Specification
 
+import net.kaleidos.grails.plugin.security.stateless.StatelessValidationException
 import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
 
 class JwtStatelessTokenProviderSpec extends Specification {
@@ -81,5 +82,16 @@ class JwtStatelessTokenProviderSpec extends Specification {
 
         then:
             thrown(RuntimeException)
+    }
+
+    void "Try to extract null token"() {
+        given: 'a null token'
+            def token = null
+
+        when: 'trying to validate and extract the token'
+            def data = tokenProvider.validateAndExtractToken(token)
+
+        then: 'an exception must be thrown'
+            thrown(StatelessValidationException)
     }
 }

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProviderSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProviderSpec.groovy
@@ -2,7 +2,6 @@ package net.kaleidos.grails.plugin.security.stateless.token
 
 import net.kaleidos.grails.plugin.security.stateless.CryptoService
 
-import grails.test.mixin.TestFor
 import spock.lang.Specification
 
 import net.kaleidos.grails.plugin.security.stateless.StatelessValidationException

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProviderSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProviderSpec.groovy
@@ -2,7 +2,6 @@ package net.kaleidos.grails.plugin.security.stateless.token
 
 import net.kaleidos.grails.plugin.security.stateless.CryptoService
 
-import grails.test.mixin.TestFor
 import spock.lang.Specification
 
 import net.kaleidos.grails.plugin.security.stateless.StatelessValidationException

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProviderSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProviderSpec.groovy
@@ -5,6 +5,7 @@ import net.kaleidos.grails.plugin.security.stateless.CryptoService
 import grails.test.mixin.TestFor
 import spock.lang.Specification
 
+import net.kaleidos.grails.plugin.security.stateless.StatelessValidationException
 import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
 
 class LegacyStatelessTokenProviderSpec extends Specification {
@@ -80,5 +81,16 @@ class LegacyStatelessTokenProviderSpec extends Specification {
 
         then:
             thrown(RuntimeException)
+    }
+
+    void "Try to extract null token"() {
+        given: 'a null token'
+            def token = null
+
+        when: 'trying to validate and extract the token'
+            def data = tokenProvider.validateAndExtractToken(token)
+
+        then: 'an exception must be thrown'
+            thrown(StatelessValidationException)
     }
 }


### PR DESCRIPTION
When receiving a request to a secured endpoint without token, the server would fail with a 500 error because of trying to execute a `startsWith` method on a `null` object.

This patch protects the `validateAndExtractToken` methods of this failure checking if the token is present and raising a `StatelessValidationException`.