### PR TITLE
Check actionName to work like index when null

### DIFF
--- a/grails-app/conf/net/kaleidos/grails/plugin/security/stateless/SecurityStatelessFilters.groovy
+++ b/grails-app/conf/net/kaleidos/grails/plugin/security/stateless/SecurityStatelessFilters.groovy
@@ -14,6 +14,9 @@ class SecurityStatelessFilters {
             if (clazz.isAnnotationPresent(SecuredStateless)) {
                 return true
             }
+            if (!actionName) {
+                actionName = controller.defaultAction
+            }
             def method = clazz.methods.find{actionName == it.name}
             if (method) {
                 return method.isAnnotationPresent(SecuredStateless)


### PR DESCRIPTION
When pointing an url directly to a controller in grails, the actionName
field is null but the framework's behaviour it to use the
controller.defaultAction property.

This patch adapts the plugin's filter logic to this grails behaviour.