### PR TITLE
Add check for exception when validating the token

### DIFF
--- a/grails-app/conf/net/kaleidos/grails/plugin/security/stateless/SecurityStatelessFilters.groovy
+++ b/grails-app/conf/net/kaleidos/grails/plugin/security/stateless/SecurityStatelessFilters.groovy
@@ -1,5 +1,7 @@
 package net.kaleidos.grails.plugin.security.stateless
 
+import groovy.json.JsonBuilder
+
 import net.kaleidos.grails.plugin.security.stateless.annotation.SecuredStateless
 import org.apache.commons.lang.WordUtils
 
@@ -31,12 +33,23 @@ class SecurityStatelessFilters {
                 }
 
                 def authorization = request.getHeader("Authorization")
-                def map = statelessTokenProvider.validateAndExtractToken(authorization)
+                try {
+                    def map = statelessTokenProvider.validateAndExtractToken(authorization)
+                } catch (StatelessValidationException e) {
+                    Closure getJsonErrorBytes = { String error ->
+                        Map errorMap = [message: error]
+                        String jsonMap = (new JsonBuilder(errorMap)).toString()
+                        return jsonMap.bytes
+                    }
+                    response.status = 401
+                    response.outputStream << getJsonErrorBytes(e.message)
+                    return false
+                }
+
                 if (map) {
                     request.securityStatelessMap = map
                     return true
                 }
-
                 response.status = 401
                 return false
             }


### PR DESCRIPTION
In the stateless filter, the validation of the token is suitable of
throwing exceptions, but those were unchecked so the server could fail
with a 500 error.

This patch is a proposal of protecting this validation with a simple
error message with the 401, formatted as

```js
401 {"message": exception.message}
```