### PR TITLE
Change generateToken to add salt as optional on both providers

### DIFF
--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProvider.groovy
@@ -21,7 +21,7 @@ class JwtStatelessTokenProvider implements StatelessTokenProvider {
 
     CryptoService cryptoService
 
-    String generateToken(String userName, String salt, Map<String,String> extraData=[:]){
+    String generateToken(String userName, String salt=null, Map<String,String> extraData=[:]){
         def data = [username:userName]
 
         if (extraData) {

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProvider.groovy
@@ -25,7 +25,7 @@ class LegacyStatelessTokenProvider implements StatelessTokenProvider {
 
     CryptoService cryptoService
 
-    String generateToken(String userName, String salt, Map<String,String> extraData=[:]){
+    String generateToken(String userName, String salt=null, Map<String,String> extraData=[:]){
         def data = [username:userName, extradata: extraData]
 
         if (salt != null) {

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProviderSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProviderSpec.groovy
@@ -4,6 +4,7 @@ import net.kaleidos.grails.plugin.security.stateless.CryptoService
 
 import grails.test.mixin.TestFor
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
 
@@ -16,7 +17,8 @@ class JwtStatelessTokenProviderSpec extends Specification {
         tokenProvider.cryptoService.init 'secret'
     }
 
-    void "generate a token and then extract it"() {
+    @Unroll
+    void "generate a token and then extract it [salt=#salt]"() {
         setup:
             def username = 'palba'
             def token = tokenProvider.generateToken(username, salt)
@@ -31,7 +33,7 @@ class JwtStatelessTokenProviderSpec extends Specification {
             data.salt == salt
 
         where:
-            salt = "salt"
+            salt << ["salt", null]
     }
 
     void "generate a token with extra data"() {

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProviderSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProviderSpec.groovy
@@ -4,6 +4,7 @@ import net.kaleidos.grails.plugin.security.stateless.CryptoService
 
 import grails.test.mixin.TestFor
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
 
@@ -16,7 +17,8 @@ class LegacyStatelessTokenProviderSpec extends Specification {
         tokenProvider.cryptoService.init 'secret'
     }
 
-    void "generate a token and then extract it"() {
+    @Unroll
+    void "generate a token and then extract it [salt=#salt]"() {
         setup:
             def username = 'palba'
             def token = tokenProvider.generateToken(username, salt)
@@ -31,7 +33,7 @@ class LegacyStatelessTokenProviderSpec extends Specification {
             data.salt == salt
 
         where:
-            salt = "salt"
+            salt << ["salt", null]
     }
 
     void "generate a token with extra data"() {


### PR DESCRIPTION
The token salt is an optional security technique that plugin users may
or may not implement, so both `LegacyStatelessTokenProvider` and
`JwtStatelessTokenProvider` have been modified to accept `salt` as
an **optional** parameter.

The methods themselves already supported `salt` being `null`, so nothing
more than the sign of the method have been changed, and tests added.