### PR TITLE
Added configuration for optional response status

### DIFF
--- a/SecurityStatelessGrailsPlugin.groovy
+++ b/SecurityStatelessGrailsPlugin.groovy
@@ -133,8 +133,13 @@ class SecurityStatelessGrailsPlugin {
 
         ctx.cryptoService.init "${conf.secretKey}"
 
+        if (conf.expiresStatusCode) {
+            ctx.statelessAuthenticationFailureHandler.init(conf.expiresStatusCode)
+        }
+
         if (conf.expirationTime) {
             ctx.statelessTokenValidator.init(new Integer(conf.expirationTime))
+            ctx.statelessTokenProvider.init(new Integer(conf.expirationTime))
         }
 
         if (!conf?.springsecurity || !conf?.springsecurity.integration) {

--- a/grails-app/conf/net/kaleidos/grails/plugin/security/stateless/SecurityStatelessFilters.groovy
+++ b/grails-app/conf/net/kaleidos/grails/plugin/security/stateless/SecurityStatelessFilters.groovy
@@ -4,6 +4,7 @@ import groovy.json.JsonBuilder
 
 import net.kaleidos.grails.plugin.security.stateless.annotation.SecuredStateless
 import org.apache.commons.lang.WordUtils
+import net.kaleidos.grails.plugin.security.stateless.exception.StatelessValidationException
 
 class SecurityStatelessFilters {
 

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/ForbiddenEntryPoint.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/ForbiddenEntryPoint.groovy
@@ -8,9 +8,12 @@ import javax.servlet.http.HttpServletResponse
 
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
+import groovy.util.logging.Slf4j
 
+@Slf4j
 public class ForbiddenEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException e) throws IOException, ServletException {
+        log.debug "Forbidden: $e"
         response.status = HttpServletResponse.SC_UNAUTHORIZED
         response.contentType = "application/json"
         response.outputStream << '{"error" : "Access Denied", "message" : "' + e.message + '"}'

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/JsonDeniedHandler.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/JsonDeniedHandler.groovy
@@ -8,9 +8,12 @@ import javax.servlet.http.HttpServletResponse
 
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.web.access.AccessDeniedHandler
+import groovy.util.logging.Slf4j
 
+@Slf4j
 public class JsonDeniedHandler implements AccessDeniedHandler {
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException e) throws IOException, ServletException {
+        log.debug "Denied: $e"
         response.status = HttpServletResponse.SC_UNAUTHORIZED
         response.contentType = "application/json"
         response.outputStream << '{"error" : "Access Denied", "message" : "' + e.message + '"}'

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/exception/ExpiredTokenException.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/exception/ExpiredTokenException.groovy
@@ -1,0 +1,15 @@
+package net.kaleidos.grails.plugin.security.stateless.exception
+
+import groovy.transform.CompileStatic
+import org.springframework.security.core.AuthenticationException
+
+@CompileStatic
+class ExpiredTokenException extends AuthenticationException {
+    ExpiredTokenException(String message) {
+        super(message)
+    }
+
+    ExpiredTokenException(String message, Throwable cause) {
+        super(message, cause)
+    }
+}

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/exception/StatelessValidationException.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/exception/StatelessValidationException.groovy
@@ -1,4 +1,4 @@
-package net.kaleidos.grails.plugin.security.stateless
+package net.kaleidos.grails.plugin.security.stateless.exception
 
 import groovy.transform.CompileStatic
 

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessAuthenticationFilter.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/filter/StatelessAuthenticationFilter.groovy
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 import net.kaleidos.grails.plugin.security.stateless.token.StatelessAuthenticationToken
-import net.kaleidos.grails.plugin.security.stateless.StatelessValidationException
+import net.kaleidos.grails.plugin.security.stateless.exception.StatelessValidationException
 
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
 import org.springframework.security.authentication.AuthenticationProvider

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/provider/StatelessAuthenticationProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/provider/StatelessAuthenticationProvider.groovy
@@ -16,6 +16,7 @@ import org.springframework.util.Assert
 import net.kaleidos.grails.plugin.security.stateless.token.StatelessTokenProvider
 import net.kaleidos.grails.plugin.security.stateless.token.StatelessAuthenticationToken
 import net.kaleidos.grails.plugin.security.stateless.token.StatelessTokenValidator
+import net.kaleidos.grails.plugin.security.stateless.exception.ExpiredTokenException
 
 
 @CompileStatic
@@ -42,7 +43,7 @@ class StatelessAuthenticationProvider implements AuthenticationProvider {
             UserDetails userDetails = userDetailsService.loadUserByUsername((String)securityStatelessMap.username, true)
 
             if (!statelessTokenValidator.validate(securityStatelessMap, userDetails)){
-                throw new BadCredentialsException("Token invalid")
+                throw new ExpiredTokenException("Token invalid")
             }
 
             log.debug "Authentication result: ${authenticationResult}"

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProvider.groovy
@@ -13,13 +13,18 @@ import org.joda.time.format.DateTimeFormatter
 import org.joda.time.format.ISODateTimeFormat
 
 import net.kaleidos.grails.plugin.security.stateless.CryptoService
-import net.kaleidos.grails.plugin.security.stateless.StatelessValidationException
+import net.kaleidos.grails.plugin.security.stateless.exception.StatelessValidationException
 
 @Slf4j
 class JwtStatelessTokenProvider implements StatelessTokenProvider {
     private static final String BEARER = "Bearer "
 
     CryptoService cryptoService
+    Integer expirationTime
+
+    public void init(Integer expirationTime) {
+        this.expirationTime = expirationTime
+    }
 
     String generateToken(String userName, String salt=null, Map<String,String> extraData=[:]){
         def data = [username:userName]
@@ -34,6 +39,10 @@ class JwtStatelessTokenProvider implements StatelessTokenProvider {
 
         DateTimeFormatter formatter = ISODateTimeFormat.dateTime()
         data["issued_at"] = formatter.print(new DateTime())
+
+        if (expirationTime != null) {
+            data["expires_at"] = formatter.print(new DateTime().plusMinutes(expirationTime))
+        }
 
         String header = new JsonBuilder([alg:"HS256", typ: "JWT"])
         String payload = new JsonBuilder(data).toString()

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProvider.groovy
@@ -13,7 +13,7 @@ import org.joda.time.format.DateTimeFormatter
 import org.joda.time.format.ISODateTimeFormat
 
 import net.kaleidos.grails.plugin.security.stateless.CryptoService
-import net.kaleidos.grails.plugin.security.stateless.StatelessValidationException
+import net.kaleidos.grails.plugin.security.stateless.exception.StatelessValidationException
 
 
 @CompileStatic
@@ -24,6 +24,11 @@ class LegacyStatelessTokenProvider implements StatelessTokenProvider {
     private static final String BEARER = "Bearer "
 
     CryptoService cryptoService
+    Integer expirationTime
+
+    public void init(Integer expirationTime) {
+        this.expirationTime = expirationTime
+    }
 
     String generateToken(String userName, String salt=null, Map<String,String> extraData=[:]){
         def data = [username:userName, extradata: extraData]

--- a/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/StatelessTokenProvider.groovy
+++ b/src/groovy/net/kaleidos/grails/plugin/security/stateless/token/StatelessTokenProvider.groovy
@@ -1,6 +1,7 @@
 package net.kaleidos.grails.plugin.security.stateless.token
 
 interface StatelessTokenProvider {
+    void init(Integer expirationTime)
     String generateToken(String userName, String salt, Map<String,String> extraData)
     Map validateAndExtractToken(String token)
 }

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProviderSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/token/JwtStatelessTokenProviderSpec.groovy
@@ -5,7 +5,7 @@ import net.kaleidos.grails.plugin.security.stateless.CryptoService
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import net.kaleidos.grails.plugin.security.stateless.StatelessValidationException
+import net.kaleidos.grails.plugin.security.stateless.exception.StatelessValidationException
 import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
 
 class JwtStatelessTokenProviderSpec extends Specification {

--- a/test/unit/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProviderSpec.groovy
+++ b/test/unit/net/kaleidos/grails/plugin/security/stateless/token/LegacyStatelessTokenProviderSpec.groovy
@@ -5,7 +5,7 @@ import net.kaleidos.grails.plugin.security.stateless.CryptoService
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import net.kaleidos.grails.plugin.security.stateless.StatelessValidationException
+import net.kaleidos.grails.plugin.security.stateless.exception.StatelessValidationException
 import net.kaleidos.grails.plugin.security.stateless.provider.UserSaltProvider
 
 class LegacyStatelessTokenProviderSpec extends Specification {


### PR DESCRIPTION
I need to return different response codes to distinguish between a "wrong" token and an expired token.

This PR makes possible to configure this special response code. Adds a new configuration that if not present will retrieve a 401 response code but if present will return the configured one.