### PR TITLE
Declare map variable outside try block to have it available outside the try context

### DIFF
--- a/grails-app/conf/net/kaleidos/grails/plugin/security/stateless/SecurityStatelessFilters.groovy
+++ b/grails-app/conf/net/kaleidos/grails/plugin/security/stateless/SecurityStatelessFilters.groovy
@@ -37,8 +37,9 @@ class SecurityStatelessFilters {
                 }
 
                 def authorization = request.getHeader("Authorization")
+                def map
                 try {
-                    def map = statelessTokenProvider.validateAndExtractToken(authorization)
+                    map = statelessTokenProvider.validateAndExtractToken(authorization)
                 } catch (StatelessValidationException e) {
                     Closure getJsonErrorBytes = { String error ->
                         Map errorMap = [message: error]


### PR DESCRIPTION
As we are using the `map` variable later in the method, it needs to be declared outside the try block to avoid errors like the following:

```
| Error 2015-03-21 09:05:10,167 [http-bio-8080-exec-6] ERROR errors.GrailsExceptionResolver  - MissingPropertyException occurred when processing request: [GET] /
No such property: map for class: net.kaleidos.grails.plugin.security.stateless.SecurityStatelessFilters. Stacktrace follows:
Message: No such property: map for class: net.kaleidos.grails.plugin.security.stateless.SecurityStatelessFilters
    Line | Method
->>   53 | doCall    in net.kaleidos.grails.plugin.security.stateless.SecurityStatelessFilters$_closure1_closure4_closure5$$EP7YGHfE
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
|    198 | doFilter  in grails.plugin.cache.web.filter.PageFragmentCachingFilter
|     63 | doFilter  in grails.plugin.cache.web.filter.AbstractFilter
|   1142 | runWorker in java.util.concurrent.ThreadPoolExecutor
|    617 | run . . . in java.util.concurrent.ThreadPoolExecutor$Worker
^    745 | run       in java.lang.Thread
```